### PR TITLE
release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.0.1
+
+support python 3.10 style optionals (declared as `type | None` instead of `Optional[type]`)
+
 # v2.0.0
 
 transitioned to a decorator instead of a class to inherit from.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "strongpods"
-version = "2.0.0"
+version = "2.0.1"
 authors = [{ name = "Tudor Oancea", email = "oancea.tudor@icloud.com" }]
 dependencies = ["numpy"]
 description = "A tiny and simple library for Strongly typed Plain Old Data Structures."

--- a/strongpods/core.py
+++ b/strongpods/core.py
@@ -2,10 +2,14 @@
 import warnings
 from enum import Enum
 from inspect import getmembers, isroutine
+from sys import version_info
 from typing import Tuple, Type, Union, get_args, get_origin
-from types import UnionType
 
 import numpy as np
+
+if version_info.minor >= 10:
+    from types import UnionType
+
 
 __all__ = [
     "set_verbosity_level",
@@ -52,7 +56,10 @@ def _log_error(
 def _is_optional(t: type) -> bool:
     # NOTE:: if t is declared as Optional[type], then get_origin(t) is Union, if it is declared as type | None, then
     # get_origin(t) is UnionType.
-    return get_origin(t) in (Union, UnionType) and type(None) in get_args(t)
+    if version_info.minor < 10:
+        return get_origin(t) is Union and type(None) in get_args(t)
+    else:
+        return get_origin(t) in (Union, UnionType) and type(None) in get_args(t)
 
 
 def _is_enum(t: type) -> bool:

--- a/strongpods/core.py
+++ b/strongpods/core.py
@@ -3,6 +3,7 @@ import warnings
 from enum import Enum
 from inspect import getmembers, isroutine
 from typing import Tuple, Type, Union, get_args, get_origin
+from types import UnionType
 
 import numpy as np
 
@@ -49,7 +50,9 @@ def _log_error(
 
 
 def _is_optional(t: type) -> bool:
-    return get_origin(t) is Union and type(None) in get_args(t)
+    # NOTE:: if t is declared as Optional[type], then get_origin(t) is Union, if it is declared as type | None, then
+    # get_origin(t) is UnionType.
+    return get_origin(t) in (Union, UnionType) and type(None) in get_args(t)
 
 
 def _is_enum(t: type) -> bool:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -315,6 +315,8 @@ class TestVerbosityLevel:
 class TestTypeDeductionHelpers:
     def test_is_optional(self):
         assert _is_optional(Optional[int])
+        assert _is_optional(Union[int, None])
+        assert _is_optional(int | None)
         assert not _is_optional(int)
         assert not _is_optional(127)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from sys import version_info
 from typing import Optional, Union
 
 import numpy as np
@@ -316,7 +317,9 @@ class TestTypeDeductionHelpers:
     def test_is_optional(self):
         assert _is_optional(Optional[int])
         assert _is_optional(Union[int, None])
-        assert _is_optional(int | None)
+        if version_info.minor >= 10:
+            assert _is_optional(int | None)
+
         assert not _is_optional(int)
         assert not _is_optional(127)
 


### PR DESCRIPTION
In this PR we add support for python 3.10 optionals ( written simply as `type | None` instead of `Optional[type]`)